### PR TITLE
handle exceptions outside the snippet but in the embedded module

### DIFF
--- a/src/pytest_markdown_docs/plugin.py
+++ b/src/pytest_markdown_docs/plugin.py
@@ -193,12 +193,12 @@ def find_object_tests_recursive(
 class MarkdownDocstringCodeModule(pytest.Module):
     def collect(self):
         module = import_path(self.fspath, root=self.config.rootpath)
-        for test_code, fixture_names, start_line in find_object_tests_recursive(
-            module.__name__, module.__name__, module
+        for i, (test_code, fixture_names, start_line) in enumerate(
+            find_object_tests_recursive(module.__name__, module.__name__, module)
         ):
             yield MarkdownInlinePythonItem.from_parent(
                 self,
-                name=str(self.fspath),
+                name=f"{self.fspath}#{i+1}",
                 code=test_code,
                 usefixtures=fixture_names,
                 start_line=start_line,


### PR DESCRIPTION
I ran into an issue where `module.py` would have some snippet embedded in it that caused an exception in `module.py` but outside the snippet. But because of the code 

```
        for frame_summary in stack_summary:
            if frame_summary.filename == self.name:
```

I think it would match the snippet to the surrounding module which caused this error:

```
INTERNALERROR>   File "/Users/erikbern/python3.10-env/lib/python3.10/site-packages/_pytest/runner.py", line 365, in pytest_runtest_makereport
INTERNALERROR>     return TestReport.from_item_and_call(item, call)
INTERNALERROR>   File "/Users/erikbern/python3.10-env/lib/python3.10/site-packages/_pytest/reports.py", line 345, in from_item_and_call
INTERNALERROR>     longrepr = item.repr_failure(excinfo)
INTERNALERROR>   File "/Users/erikbern/pytest-markdown-docs/src/pytest_markdown_docs/plugin.py", line 101, in repr_failure
INTERNALERROR>     rawlines[frame_summary.lineno - 1] if frame_summary.lineno else ""
INTERNALERROR> IndexError: list index out of range
```

Changing the name of each snippet to something unique resolves this