### PR TITLE
Add copy button to readme's pip install cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ assert result == "hello"
 
 ## Usage
 
-First, make sure to install the plugin, e.g. `pip install pytest-markdown-docs`
+First, make sure to install the plugin:
+
+```shell
+pip install pytest-markdown-docs
+```
 
 To enable markdown python tests, pass the `--markdown-docs` flag to `pytest`:
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ assert result == "hello"
 First, make sure to install the plugin, e.g. `pip install pytest-markdown-docs`
 
 To enable markdown python tests, pass the `--markdown-docs` flag to `pytest`:
+
 ```shell
 pytest --markdown-docs
 ```
 
 You can also use the `markdown-docs` flag to filter *only* markdown-docs tests:
+
 ```shell
 pytest --markdown-docs -m markdown-docs
 ```
@@ -111,8 +113,8 @@ captured = capsys.readouterr()
 assert captured.out == "hello\n"
 ```
 ````
-As you can see above, the fixture value will be injected as a global. For `autouse=True` fixtures, the value is only injected as a global if it's explicitly added using a `fixture:<name>` marker.
 
+As you can see above, the fixture value will be injected as a global. For `autouse=True` fixtures, the value is only injected as a global if it's explicitly added using a `fixture:<name>` marker.
 
 ### Depending on previous snippets
 
@@ -131,6 +133,7 @@ assert a + " world" == "hello world"
 ````
 
 ## Testing of this plugin
+
 You can test this module itself (sadly not using markdown tests at the moment) using pytest:
 
 ```shell
@@ -138,14 +141,15 @@ You can test this module itself (sadly not using markdown tests at the moment) u
 ```
 
 Or for fun, you can use this plugin to include testing of the validity of snippets in this README.md file:
+
 ```shell
 > poetry run pytest --markdown-docs
 ```
 
-
 ## Known issues
+
 * Only tested with pytest 6.2.5. There seem to be some minor issue with pytest >7 due to changes of some internal functions in pytest, but that should be relatively easy to fix. Contributions are welcome :)
 * Code for docstring-inlined test discovery can probably be done better (similar to how doctest does it). Currently, seems to sometimes traverse into Python's standard library which isn't great...
 * Traceback logic is extremely hacky, wouldn't be surprised if the tracebacks look weird sometimes
-    - Line numbers are "wrong" for docstring-inlined snippets (since we don't know where in the file the docstring starts)
-    - Line numbers are "wrong" for continuation blocks even in pure markdown files (can be worked out with some refactoring)
+  * Line numbers are "wrong" for docstring-inlined snippets (since we don't know where in the file the docstring starts)
+  * Line numbers are "wrong" for continuation blocks even in pure markdown files (can be worked out with some refactoring)


### PR DESCRIPTION
Just a small QOL improvement to make the install command easier to copy.

Also, love the fact that you support `.svx` files out of the box! 👍 