### PR TITLE
Show useful error if there is an error when looking up a fixture

### DIFF
--- a/src/pytest_markdown_docs/plugin.py
+++ b/src/pytest_markdown_docs/plugin.py
@@ -29,6 +29,7 @@ class MarkdownInlinePythonItem(pytest.Item):
         super().__init__(name, parent)
         self.add_marker(MARKER_NAME)
         self.code = code
+        self.obj = None
         self.user_properties.append(("code", code))
         self.start_line = start_line
         self.fake_line_numbers = fake_line_numbers

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -180,3 +180,28 @@ def initialize_specific():
     )
     result = testdir.runpytest("--markdown-docs")
     result.assert_outcomes(passed=1)
+
+
+def test_non_existing_fixture_error(testdir):
+    testdir.makeconftest(
+        """
+import pytest
+
+@pytest.fixture()
+def foo():
+    pass
+"""
+    )
+
+    testdir.makefile(
+        ".md",
+        """
+        \"\"\"
+        ```python fixture:bar
+        ```
+        \"\"\"
+    """,
+    )
+    result = testdir.runpytest("--markdown-docs")
+    assert "fixture 'bar' not found" in result.stdout.str()
+    result.assert_outcomes(errors=1)


### PR DESCRIPTION
Previously a missing fixture would output a cryptic pytest-internal error: 
```
INTERNALERROR>     stack = [self.request._pyfuncitem.obj]
INTERNALERROR> AttributeError: 'MarkdownInlinePythonItem' object has no attribute 'obj'
```

After this fix it will instead be:
```
=================================================== ERRORS ====================================================
____ ERROR at setup of docstring for ... _____
file , line 0: source code not available
E       fixture 'foo' not found

```