### PR TITLE
Loosen version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["LICENSE"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-markdown-it-py = "~=2.2.0"
+markdown-it-py = ">=2.2.0"
 
 [tool.poetry.plugins]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["LICENSE"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-markdown-it-py = ">=2.2.0"
+markdown-it-py = ">=2.2.0, <4.0"
 
 [tool.poetry.plugins]
 


### PR DESCRIPTION
Right now this is giving an error on installation:

```
ERROR: pytest-markdown-docs 0.4.1 has requirement markdown-it-py<1.2.0,>=1.1.0, but you'll have markdown-it-py 3.0.0 which is incompatible.
```
