### PR TITLE
Add support for `pycon` format

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pytest --markdown-docs -m markdown-docs
 
 ### Detection conditions
 
-Fence blocks (` ``` `) starting with the `python`, `python3` or `py` language definitions are detected as tests in:
+Fence blocks (` ``` `) starting with the `python`, `python3`, `pycon`, or `py` language definitions are detected as tests in:
 
 * Python (.py) files, within docstrings of classes and functions
 * `.md`, `.mdx` and `.svx` files

--- a/src/pytest_markdown_docs/plugin.py
+++ b/src/pytest_markdown_docs/plugin.py
@@ -156,7 +156,7 @@ def extract_code_blocks(
 
         lang = code_info[0] if code_info else None
 
-        if lang in ("py", "python", "python3") and not "notest" in code_info:
+        if lang in ("py", "python", "python3", "pycon") and not "notest" in code_info:
             code_block = block.content
 
             if "continuation" in code_info:

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -17,6 +17,10 @@ def test_docstring_markdown(testdir):
             import pytest_markdown_docs
             pytest_markdown_docs.side_effect = "hello"
             ```
+            
+            ```pycon
+            >>> assert a + " world" == "hello world"
+            ```
 
             ```
             not a python block
@@ -48,7 +52,7 @@ def test_docstring_markdown(testdir):
     """
     )
     result = testdir.runpytest("--markdown-docs")
-    result.assert_outcomes(passed=2, failed=2)
+    result.assert_outcomes(passed=3, failed=2)
     assert (
         getattr(pytest_markdown_docs, "side_effect", None) == "hello"
     )  # hack to make sure the test actually does something
@@ -69,13 +73,17 @@ def test_markdown_text_file(testdir):
         ```python
         assert a + " world" == "hello world"
         ```
+        
+        ```pycon
+        >>> assert a + " world" == "hello world"
+        ```
         \"\"\"
     """,
     )
 
     # run all tests with pytest
     result = testdir.runpytest("--markdown-docs")
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(passed=2)
 
 
 def test_traceback(testdir):


### PR DESCRIPTION
This PR proposes to add support for the `pycon` format. As shown for example in [blacken-docs](https://github.com/adamchainz/blacken-docs#markdown), one of the code block formats is `pycon` which is not supported by the current implementation. I think it would be great to add support to this format as it seems the changes are very small. The PR also adds some tests to check the new `pycon` format.

**Issue:** N/A
