### PR TITLE
Release 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Or for fun, you can use this plugin to include testing of the validity of snippe
 ```
 
 ## Known issues
-
-* Tested with pytest 6 and 7. There is a minor incompatibility with pytest 8.
 * Code for docstring-inlined test discovery can probably be done better (similar to how doctest does it). Currently, seems to sometimes traverse into Python's standard library which isn't great...
 * Traceback logic is extremely hacky, wouldn't be surprised if the tracebacks look weird sometimes
   * Line numbers are "wrong" for docstring-inlined snippets (since we don't know where in the file the docstring starts)
   * Line numbers are "wrong" for continuation blocks even in pure markdown files (can be worked out with some refactoring)
+* There are probably more appropriate ways to use pytest internal APIs to get more features "for free" - current state of the code is a bit "patch it til' it works".
+* Assertions are not rewritten w/ pretty data structure inspection like they are with regular pytest tests by default

--- a/poetry.lock
+++ b/poetry.lock
@@ -423,4 +423,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c3a487db026c237855e9bed7222c4a36a146b6a6acde283826d92411ab958e62"
+content-hash = "53beebbacc0ed83e43032244918c1f5b5a3abec0a7ff19f1583330330452e5f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-markdown-docs"
-version = "0.4.3"
+version = "0.5.0"
 description = "Run markdown code fences through pytest"
 readme = "README.md"
 authors = ["Modal Labs", "Elias Freider <elias@modal.com>"]
@@ -12,6 +12,7 @@ include = ["LICENSE"]
 [tool.poetry.dependencies]
 python = "^3.8"
 markdown-it-py = ">=2.2.0, <4.0"
+pytest = ">=7.0.0"
 
 [tool.poetry.plugins]
 

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -78,10 +78,25 @@ def test_markdown_text_file(testdir):
         ```
     """,
     )
-
-    # run all tests with pytest
     result = testdir.runpytest("--markdown-docs")
     result.assert_outcomes(passed=1, failed=2)
+
+
+def test_continuation(testdir):
+    testdir.makefile(
+        ".md",
+        """
+        ```python
+        b = "hello"
+        ```
+
+        ```python continuation
+        assert b + " world" == "hello world"
+        ```
+    """,
+    )
+    result = testdir.runpytest("--markdown-docs")
+    result.assert_outcomes(passed=2)
 
 
 def test_traceback(testdir):


### PR DESCRIPTION
Release notes:
* Add support for pytest 8
* Drop support for pytest 6
* Fix critical bug allowing syntax errors to pass tests

Minor "bonus" changes in this patch:
* Updated readme
* Updated version number
* Include explicit pytest>7 dependency
* One additional unit test for continuation blocks