### PR TITLE
Add support for specifying metadata options in MDX comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ assert a + " world" == "hello world"
 ```
 ````
 
+## MDX Comments for Metadata Options
+In .mdx files, you can use MDX comments to provide additional options for code blocks. These comments should be placed immediately before the code block and take the following form:
+
+```mdx
+{/* pmd-metadata: notest fixture:capsys */}
+```python
+print("hello")
+captured = capsys.readouterr()
+assert captured.out == "hello\n"
+```
+
+The following options can be specified using MDX comments:
+
+* notest: Exclude the code block from testing.
+* fixture:<name>: Apply named pytest fixtures to the code block.
+* continuation: Continue from the previous code block, allowing you to carry over state.
+
+This approach allows you to add metadata to the code block without modifying the code fence itself, making it particularly useful in MDX environments.
+
 ## Testing of this plugin
 
 You can test this module itself (sadly not using markdown tests at the moment) using pytest:

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -322,7 +322,7 @@ def another_fixture():
     )
 
     testdir.makefile(
-        ".md",
+        ".mdx",
         """
         {/* pmd-metadata: fixture:initialize_specific fixture:another_fixture */}
         ```python

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -322,7 +322,7 @@ def another_fixture():
     )
 
     testdir.makefile(
-        ".mdx",
+        ".md",
         """
         {/* pmd-metadata: fixture:initialize_specific fixture:another_fixture */}
         ```python


### PR DESCRIPTION
### Summary

This PR adds support for specifying test metadata in `.mdx` files using MDX-style comments (`{/* pmd-metadata: */}`) placed above code blocks. This should support all existing options and allow for easily adding more without having to alter the MDX parsing logic.

### Example:
```mdx
{/* pmd-metadata: notest, fixture:capsys */}
```python
print("hello")
captured = capsys.readouterr()
assert captured.out == "hello\n"
```

* Updated documentation with MDX metadata usage.
* Minor refactoring for readability and metadata extraction.

**Issue:** https://github.com/modal-labs/pytest-markdown-docs/issues/28
