### PR TITLE
Adds pytest_markdown_docs_markdown_it for custom markdownit parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,21 @@ The following options can be specified using MDX comments:
 
 This approach allows you to add metadata to the code block without modifying the code fence itself, making it particularly useful in MDX environments.
 
+## Customizing your own custom MarkdownIt parser
+
+You can configure your own [Markdown-it-py](https://pypi.org/project/markdown-it-py/) parser used by `pytest-markdown-docs` by defining a `pytest_markdown_docs_markdown_it`. For example, you can support
+`mkdocs`'s admonitions with:
+
+```python
+def pytest_markdown_docs_markdown_it():
+    import markdown_it
+    from mdit_py_plugins.admon import admon_plugin
+
+    mi = markdown_it.MarkdownIt(config="commonmark")
+    mi.use(admon_plugin)
+    return mi
+```
+
 ## Testing of this plugin
 
 You can test this module itself (sadly not using markdown tests at the moment) using pytest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,5 @@ dev-dependencies = [
     "pre-commit>=3.5.0",
     "pytest~=8.1.0",
     "ruff~=0.9.10",
+    "mdit-py-plugins~=0.4.2"
 ]

--- a/src/pytest_markdown_docs/hooks.py
+++ b/src/pytest_markdown_docs/hooks.py
@@ -1,3 +1,4 @@
+import pytest
 import typing
 
 if typing.TYPE_CHECKING:
@@ -8,5 +9,6 @@ def pytest_markdown_docs_globals() -> typing.Dict[str, typing.Any]:
     return {}
 
 
+@pytest.hookspec(firstresult=True)
 def pytest_markdown_docs_markdown_it() -> "MarkdownIt":
     """Configure a custom markdown_it.MarkdownIt parser."""

--- a/src/pytest_markdown_docs/hooks.py
+++ b/src/pytest_markdown_docs/hooks.py
@@ -1,5 +1,12 @@
 import typing
 
+if typing.TYPE_CHECKING:
+    from markdown_it import MarkdownIt
+
 
 def pytest_markdown_docs_globals() -> typing.Dict[str, typing.Any]:
     return {}
+
+
+def pytest_markdown_docs_markdown_it() -> "MarkdownIt":
+    """Configure a custom markdown_it.MarkdownIt parser."""

--- a/src/pytest_markdown_docs/plugin.py
+++ b/src/pytest_markdown_docs/plugin.py
@@ -131,14 +131,7 @@ def extract_fence_tests(
     markdown_type: str = "md",
     fence_syntax: FenceSyntax = FenceSyntax.default,
 ) -> typing.Generator[FenceTestDefinition, None, None]:
-    if not markdown_it_parser:
-        from markdown_it import MarkdownIt
-
-        mi = MarkdownIt(config="commonmark")
-    else:
-        mi = markdown_it_parser
-
-    tokens = mi.parse(markdown_string)
+    tokens = markdown_it_parser.parse(markdown_string)
 
     prev = ""
     for i, block in enumerate(tokens):
@@ -386,3 +379,10 @@ def pytest_addoption(parser: Parser) -> None:
 
 def pytest_addhooks(pluginmanager):
     pluginmanager.add_hookspecs(hooks)
+
+
+@pytest.hookimpl
+def pytest_markdown_docs_markdown_it() -> "MarkdownIt":
+    from markdown_it import MarkdownIt
+
+    return MarkdownIt(config="commonmark")

--- a/src/pytest_markdown_docs/plugin.py
+++ b/src/pytest_markdown_docs/plugin.py
@@ -124,19 +124,19 @@ def get_prefixed_strings(
 
 
 def extract_fence_tests(
-    markdown_it_parsers: typing.List["MarkdownIt"],
+    markdown_it_parser: "MarkdownIt",
     markdown_string: str,
     start_line_offset: int,
     source_path: pathlib.Path,
     markdown_type: str = "md",
     fence_syntax: FenceSyntax = FenceSyntax.default,
 ) -> typing.Generator[FenceTestDefinition, None, None]:
-    if not markdown_it_parsers:
+    if not markdown_it_parser:
         from markdown_it import MarkdownIt
 
         mi = MarkdownIt(config="commonmark")
     else:
-        mi = markdown_it_parsers[0]
+        mi = markdown_it_parser
 
     tokens = mi.parse(markdown_string)
 
@@ -300,13 +300,11 @@ class MarkdownDocstringCodeModule(pytest.Module):
                     or "<Unnamed obj>"
                 )
                 fence_syntax = FenceSyntax(self.config.option.markdowndocs_syntax)
-                markdown_it_parsers = (
-                    self.config.hook.pytest_markdown_docs_markdown_it()
-                )
+                markdown_it_parser = self.config.hook.pytest_markdown_docs_markdown_it()
 
                 for i, fence_test in enumerate(
                     extract_fence_tests(
-                        markdown_it_parsers,
+                        markdown_it_parser,
                         docstr,
                         docstring_offset,
                         source_path=self.path,
@@ -328,11 +326,11 @@ class MarkdownTextFile(pytest.File):
         markdown_content = self.path.read_text("utf8")
         fence_syntax = FenceSyntax(self.config.option.markdowndocs_syntax)
 
-        markdown_it_parsers = self.config.hook.pytest_markdown_docs_markdown_it()
+        markdown_it_parser = self.config.hook.pytest_markdown_docs_markdown_it()
 
         for i, fence_test in enumerate(
             extract_fence_tests(
-                markdown_it_parsers,
+                markdown_it_parser,
                 markdown_content,
                 source_path=self.path,
                 start_line_offset=0,

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -470,3 +470,43 @@ def test_custom_runner(testdir):
         ],
         consecutive=True,
     )
+
+
+def test_admonition_markdown_text_file(testdir):
+    testdir.makeconftest(
+        """
+        def pytest_markdown_docs_globals():
+            return {"a": "hello"}
+
+        def pytest_markdown_docs_markdown_it():
+            import markdown_it
+            from mdit_py_plugins.admon import admon_plugin
+
+            mi = markdown_it.MarkdownIt(config="commonmark")
+            mi.use(admon_plugin)
+            return mi
+    """
+    )
+
+    testdir.makefile(
+        ".md",
+        """
+        ??? quote
+
+            ```python
+            assert a + " world" == "hello world"
+            ```
+
+        !!! info
+            ```python
+            assert False
+            ```
+
+        ???+ note
+            ```python
+            **@ # this is a syntax error
+            ```
+    """,
+    )
+    result = testdir.runpytest("--markdown-docs")
+    result.assert_outcomes(passed=1, failed=2)


### PR DESCRIPTION
**Issue:** Fixes https://github.com/modal-labs/pytest-markdown-docs/issues/31

This PR adds a `pytest_markdown_docs_markdown_it` `pytest` hook to allow developers to customize the markdown_it parser. This means they can add plugins such as `admon_plugin` to the parser.

An alternative is to add something like https://github.com/modal-labs/pytest-markdown-docs/blob/main/src/pytest_markdown_docs/_runners.py, but using a `pytest` hook feels a little more natural with how pytest does things. For example, `pytest-xdist` has uses a `pytest_xdist_make_scheduler` to configure a custom scheduler:

https://github.com/pytest-dev/pytest-xdist/blob/f83299cd646965ac0560adddcf7204adde9f486e/src/xdist/newhooks.py#L96-L100