### PR TITLE
Support code blocks inside of HTML comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Sometimes you might wish to run code blocks that depend on entities to already
 be declared in the scope of the code, without explicitly declaring them. There
 are currently three ways you can do this with pytest-markdown:
 
-### Injecting global/local variables
+### Option 1: Injecting global/local variables
 
 If you have some common imports or other common variables that you want to make
 use of in snippets, you can add them by creating a `pytest_markdown_docs_globals`
@@ -104,7 +104,7 @@ print(myvar, math.pi)
 ```
 ````
 
-### Fixtures
+### Option 2: Fixtures
 
 You can use both `autouse=True` pytest fixtures in a conftest.py or named fixtures with
 your markdown tests. To specify named fixtures, add `fixture:<name>` markers to the code
@@ -120,7 +120,7 @@ assert captured.out == "hello\n"
 
 As you can see above, the fixture value will be injected as a global. For `autouse=True` fixtures, the value is only injected as a global if it's explicitly added using a `fixture:<name>` marker.
 
-### Depending on previous snippets
+### Option 3: Depending on previous snippets
 
 If you have multiple snippets following each other and want to keep the side
 effects from the previous snippets, you can do so by adding the `continuation`

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ print("this will not be run")
 
 Sometimes you might wish to run code blocks that depend on entities to already
 be declared in the scope of the code, without explicitly declaring them. There
-are currently two ways you can do this with pytest-markdown:
+are currently three ways you can do this with pytest-markdown:
 
 ### Injecting global/local variables
 
@@ -136,7 +136,29 @@ assert a + " world" == "hello world"
 ```
 ````
 
-### Compatibility with Material for MkDocs
+#### Hiding previous snippets
+
+If some of your snippets are to set up your code and you don't wish them
+to be displayed in the rendered markdown, you can enclose your code block
+in a comment `<!--   -->`:
+
+````markdown
+<!--```python
+# Run setup code here
+import my_library
+```-->
+
+```python continuation
+# The code you'd like users to see
+assert my_library.is_setup()
+```
+````
+
+> [!NOTE]
+> We've extended the parser to detect and run code in HTML comments but for this to work,
+> your code block must start with exactly `<!--``` ` or `<!--~~~` and finish with ` ```-->` or `~~~-->` (no spaces!) .
+
+#### Compatibility with Material for MkDocs
 
 Material for Mkdocs is not compatible with the default syntax.
 

--- a/src/pytest_markdown_docs/_comment_parser.py
+++ b/src/pytest_markdown_docs/_comment_parser.py
@@ -1,0 +1,105 @@
+"""
+Inspired by markdown-it-py and its plugins:
+    https://github.com/executablebooks/markdown-it-py/blob/master/markdown_it/rules_block/fence.py
+    https://github.com/executablebooks/markdown-it-py/blob/master/markdown_it/rules_block/html_block.py
+    https://github.com/executablebooks/mdit-py-plugins/blob/master/mdit_py_plugins/admon/index.py
+
+MIT License Copyright (c) 2020 ExecutableBookProject
+"""
+
+from markdown_it import MarkdownIt
+from markdown_it.rules_block import StateBlock
+
+MARKERS = (
+    ("<!--~~~", "~~~-->"),
+    ("<!--```", "```-->"),
+)
+LEN_OPENING_MARKER = len(MARKERS[0][0])
+
+
+def comment(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool:
+    """
+    A rule to parse comments in markdown files.
+    """
+    if state.is_code_block(startLine):
+        return False
+
+    line_start = state.bMarks[startLine] + state.tShift[startLine]
+    line_end = state.eMarks[startLine]
+
+    if line_start + LEN_OPENING_MARKER > line_end:
+        return False
+
+    # Fast check to fail if first character doesn't match
+    if state.src[line_start] != "<":
+        return False
+
+    try:
+        marker = state.src[line_start : line_start + LEN_OPENING_MARKER]
+    except IndexError:
+        return False
+
+    for start_marker in MARKERS:
+        if marker == start_marker[0]:
+            end_marker = start_marker[1]
+            break
+    else:
+        return False
+
+    # Since start is found, we can report success here in validation mode
+    if silent:
+        return True
+
+    params = state.src[line_start + LEN_OPENING_MARKER : line_end]
+
+    # search end of block
+    nextLine = startLine
+
+    haveEndMarker = False
+    while nextLine < endLine - 1:
+        nextLine += 1
+        line_start = state.bMarks[nextLine] + state.tShift[nextLine]
+        line_end = state.eMarks[nextLine]
+
+        if line_start < line_end and state.sCount[nextLine] < state.blkIndent:
+            # non-empty line with negative indent should stop the list:
+            # - ```
+            #  test
+            break
+
+        if state.is_code_block(nextLine):
+            continue
+
+        try:
+            if state.src[line_start : line_start + len(end_marker)] != end_marker:
+                continue
+        except IndexError:
+            break
+
+        
+
+        # make sure tail has spaces only
+        pos = state.skipSpaces(line_start + len(end_marker))
+        if pos < line_end:
+            continue
+
+        haveEndMarker = True
+        # found!
+        break
+
+    # If a fence has heading spaces, they should be removed from its inner block
+    length = state.sCount[startLine]
+
+    state.line = nextLine + (1 if haveEndMarker else 0)
+
+    token = state.push("fence", "code", 0)
+    token.info = params
+    token.content = state.getLines(startLine + 1, nextLine, length, True)
+    token.markup = marker
+    token.map = [startLine, state.line]
+
+    return True
+
+
+def comment_plugin(md: MarkdownIt, render=None) -> None:
+    md.block.ruler.before("html_block", "comment", comment)

--- a/src/pytest_markdown_docs/plugin.py
+++ b/src/pytest_markdown_docs/plugin.py
@@ -14,6 +14,7 @@ import logging
 from pytest_markdown_docs import hooks
 from pytest_markdown_docs.definitions import FenceTestDefinition, ObjectTestDefinition
 from pytest_markdown_docs._runners import get_runner
+from pytest_markdown_docs._comment_parser import comment_plugin
 
 if pytest.version_tuple >= (8, 0, 0):
     from _pytest.fixtures import TopRequest
@@ -294,6 +295,7 @@ class MarkdownDocstringCodeModule(pytest.Module):
                 )
                 fence_syntax = FenceSyntax(self.config.option.markdowndocs_syntax)
                 markdown_it_parser = self.config.hook.pytest_markdown_docs_markdown_it()
+                markdown_it_parser.use(comment_plugin)
 
                 for i, fence_test in enumerate(
                     extract_fence_tests(
@@ -320,6 +322,7 @@ class MarkdownTextFile(pytest.File):
         fence_syntax = FenceSyntax(self.config.option.markdowndocs_syntax)
 
         markdown_it_parser = self.config.hook.pytest_markdown_docs_markdown_it()
+        markdown_it_parser.use(comment_plugin)
 
         for i, fence_test in enumerate(
             extract_fence_tests(

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -102,6 +102,25 @@ def test_continuation(testdir):
     result.assert_outcomes(passed=2)
 
 
+def test_code_block_inside_comment(testdir):
+    testdir.makefile(
+        ".md",
+        """
+        <!--```python
+        # This code would not render because it's in a comment
+
+        b = "hello" 
+        ```--> 
+
+        ```python continuation
+        assert b == "hello"
+        ```
+    """,
+    )
+    result = testdir.runpytest("--markdown-docs")
+    result.assert_outcomes(passed=2)
+
+
 def test_traceback(testdir):
     testdir.makefile(
         ".md",

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -135,9 +135,9 @@ Error in code block:
 10   foo\(\)
      ```
 Traceback \(most recent call last\):
-  File ".*/test_traceback.md", line 10, in <module>
+  File ".*(/|\\)test_traceback.md", line 10, in <module>
     foo\(\)
-  File ".*/test_traceback.md", line 5, in foo
+  File ".*(/|\\)test_traceback.md", line 5, in foo
     raise Exception\("doh"\)
 Exception: doh
 """.strip()
@@ -404,9 +404,9 @@ def test_error_origin_after_docstring_traceback(testdir, support_dir):
     data.re_match_lines(
         [
             r"Traceback \(most recent call last\):",
-            r'\s*File ".*/docstring_error_after.py", line 5, in <module>',
+            r'\s*File ".*(/|\\)docstring_error_after.py", line 5, in <module>',
             r"\s*docstring_error_after.error_after\(\)",
-            r'\s*File ".*/docstring_error_after.py", line 11, in error_after',
+            r'\s*File ".*(/|\\)docstring_error_after.py", line 11, in error_after',
             r'\s*raise Exception\("bar"\)',
             r"\s*Exception: bar",
         ],
@@ -423,9 +423,9 @@ def test_error_origin_before_docstring_traceback(testdir, support_dir):
     data.re_match_lines(
         [
             r"Traceback \(most recent call last\):",
-            r'\s*File ".*/docstring_error_before.py", line 9, in <module>',
+            r'\s*File ".*(/|\\)docstring_error_before.py", line 9, in <module>',
             r"\s*docstring_error_before.error_before\(\)",
-            r'\s*File ".*/docstring_error_before.py", line 2, in error_before',
+            r'\s*File ".*(/|\\)docstring_error_before.py", line 2, in error_before',
             r'\s*raise Exception\("foo"\)',
             r"\s*Exception: foo",
         ],


### PR DESCRIPTION
This PR extends the markdown parser to handle lines that start with `<!--``` ` or `<!--~~~` as the start of a code fence. Admittedly, this does feel quite hacky and I'd love for better solutions. I'm thinking that perhaps, a better approach is to extend the renderers to be able to hide certain code blocks.

**Issue:** https://github.com/modal-labs/pytest-markdown-docs/issues/46
