### PR TITLE
Expose fence options on FenceTestDefinition for custom runners

### DIFF
--- a/src/pytest_markdown_docs/definitions.py
+++ b/src/pytest_markdown_docs/definitions.py
@@ -11,6 +11,11 @@ class FenceTestDefinition:
     source_path: pathlib.Path
     runner_name: typing.Optional[str]
     max_retries: int = 0
+    # All options on the fence (everything after the language in the info
+    # string, plus any mdx-comment metadata), including ones the plugin itself
+    # consumes, e.g. `fixture:foo` and `continuation`. Lets custom runners
+    # define their own options without requiring a pytest fixture per flag.
+    options: typing.FrozenSet[str] = frozenset()
 
 
 @dataclass(frozen=True)

--- a/src/pytest_markdown_docs/plugin.py
+++ b/src/pytest_markdown_docs/plugin.py
@@ -252,6 +252,7 @@ def extract_fence_tests(
                 source_path=source_path,
                 runner_name=runner_name,
                 max_retries=max_retries,
+                options=frozenset(code_options),
             )
             prev = code_block
 

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -472,6 +472,30 @@ def test_custom_runner(testdir):
     )
 
 
+def test_runner_receives_fence_options(testdir):
+    testdir.makeconftest(
+        """
+        import pytest_markdown_docs._runners
+
+        @pytest_markdown_docs._runners.register_runner()
+        class OptionsChecker(pytest_markdown_docs._runners.DefaultRunner):
+            def runtest(self, test, args):
+                assert test.options == {"runner:OptionsChecker", "my_flag", "other:value"}
+    """
+    )
+    testdir.makefile(
+        ".md",
+        """
+        ```python runner:OptionsChecker my_flag other:value
+        pass
+        ```
+    """,
+    )
+
+    result = testdir.runpytest("-v", "--markdown-docs")
+    result.assert_outcomes(passed=1)
+
+
 def test_non_python_fence_without_runner_is_ignored(testdir):
     testdir.makefile(
         ".md",


### PR DESCRIPTION
Stacked on #67.

Custom runners currently have only `fixture:` names as a per-fence metadata channel. That forces consumers to declare placeholder pytest fixtures (`return True`) for flags whose values are never used — the fixture machinery resolves each name even though the runner only reads the name as a flag.

This exposes the full set of fence options (everything after the language in the info string, plus mdx-comment metadata) as an `options: frozenset` field on `FenceTestDefinition`, so custom runners can define their own flags without involving the fixture system. Unknown plain options were already ignored by the plugin, so this is backwards compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)