### PR TITLE
Don't re-run code blocks when user code raises TypeError

### DIFF
--- a/src/pytest_markdown_docs/plugin.py
+++ b/src/pytest_markdown_docs/plugin.py
@@ -60,6 +60,20 @@ def _get_asyncio_runner(fixture_request):
         return None
 
 
+def _accepts_asyncio_runner(runner) -> bool:
+    """Check if the runner's runtest signature accepts the asyncio_runner kwarg.
+
+    Custom runners written before the kwarg was introduced may not take it.
+    """
+    try:
+        parameters = inspect.signature(runner.runtest).parameters
+    except (TypeError, ValueError):
+        return False
+    return "asyncio_runner" in parameters or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()
+    )
+
+
 class MarkdownInlinePythonItem(pytest.Item):
     def __init__(
         self,
@@ -89,6 +103,7 @@ class MarkdownInlinePythonItem(pytest.Item):
         self.fixture_request = TopRequest(self, _ispytest=True)
         self.fixture_request._fillfixtures()
         self.runner = get_runner(self.runner_name)
+        self.runner_accepts_asyncio_runner = _accepts_asyncio_runner(self.runner)
 
     def runtest(self):
         global_sets = self.parent.config.hook.pytest_markdown_docs_globals()
@@ -119,14 +134,14 @@ class MarkdownInlinePythonItem(pytest.Item):
                 capman = self.config.pluginmanager.getplugin("capturemanager")
                 asyncio_runner = _get_asyncio_runner(self.fixture_request)
                 with capman.global_and_fixture_disabled():
-                    try:
+                    if self.runner_accepts_asyncio_runner:
                         self.runner.runtest(
                             self.test_definition,
                             all_globals,
                             asyncio_runner=asyncio_runner,
                         )
-                    except TypeError:
-                        # Custom runner doesn't accept asyncio_runner kwarg
+                    else:
+                        # Custom runner doesn't accept the asyncio_runner kwarg
                         self.runner.runtest(self.test_definition, all_globals)
 
                 # Success - test passed

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -472,6 +472,43 @@ def test_custom_runner(testdir):
     )
 
 
+def test_user_code_type_error_runs_block_once(testdir):
+    """A TypeError raised by the code block itself must not re-execute the block.
+
+    The asyncio_runner compatibility fallback used to catch TypeErrors from user
+    code and run the block a second time (doubled again by each retry attempt).
+    """
+    testdir.makepyfile(
+        conftest="""
+run_counts = {}
+"""
+    )
+    testdir.makefile(
+        ".md",
+        test_file="""
+```python
+import conftest
+conftest.run_counts["plain"] = conftest.run_counts.get("plain", 0) + 1
+raise TypeError("user code error")
+```
+
+```python retry:2
+import conftest
+conftest.run_counts["retried"] = conftest.run_counts.get("retried", 0) + 1
+raise TypeError("user code error")
+```
+
+```python
+import conftest
+assert conftest.run_counts == {"plain": 1, "retried": 3}
+```
+""",
+    )
+    result = testdir.runpytest("--markdown-docs")
+    result.assert_outcomes(passed=1, failed=2)
+    result.stdout.fnmatch_lines(["*TypeError: user code error*"])
+
+
 def test_admonition_markdown_text_file(testdir):
     testdir.makeconftest(
         """


### PR DESCRIPTION
**Issue:** Fixes https://github.com/modal-labs/pytest-markdown-docs/issues/69

The `asyncio_runner` fallback from [#62](https://github.com/modal-labs/pytest-markdown-docs/pull/62) wraps `runner.runtest(...)` in `except TypeError`, so a `TypeError` raised by the user's code block also triggers the fallback and the whole block executes a second time (with `retry:N` it runs `2*(N+1)` times).

This checks the runner's `runtest` signature once in `setup()` instead of catching `TypeError` at call time. Custom runners that don't take the kwarg still work, and blocks that raise `TypeError` now run exactly once. Includes a regression test that fails on `main`.

CI won't run here: [ci.yml](https://github.com/modal-labs/pytest-markdown-docs/blob/main/.github/workflows/ci.yml) only triggers on `push`, so fork PRs don't get a run. Locally on Windows / Python 3.13 the suite is 3 failed, 41 passed, and the same three failures happen on a clean `main` checkout (its traceback tests use `/`-only path regexes that don't match Windows paths).
